### PR TITLE
最小構成のヘッダーパーシャルを追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
   </head>
 
   <body>
+    <%= render "shared/header" %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,16 @@
+<header>
+  <nav style="display: flex; justify-content: space-between; align-items: center; padding: 12px 20px; border-bottom: 1px solid #eee;">
+
+    <!-- Logo -->
+    <div>
+      <%= link_to "Beauty in English", root_path, style: "font-weight: bold; font-size: 18px; text-decoration: none;" %>
+    </div>
+
+    <!-- Right side actions -->
+    <div style="display: flex; gap: 16px;">
+      <%= link_to "Sign up", "#", style: "text-decoration: none;" %>
+      <%= link_to "Log in", "#", style: "text-decoration: none;" %>
+    </div>
+
+  </nav>
+</header>


### PR DESCRIPTION
**概要**

MVP向けのシンプルな共通ヘッダーを追加しました。

**変更内容**

- ヘッダー用パーシャルを作成
- application layout にヘッダーを組み込み
- ロゴ・サインアップ・ログインの最小ナビゲーションUIを追加

**目的**

認証機能実装前に、アプリ全体の基本ナビゲーション構造を整えるため。

**補足**

現時点ではリンクの動作は未実装です（認証導入後に対応予定）。